### PR TITLE
機能の追加

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -1025,7 +1025,8 @@ LIB_API float *network_predict_image_letterbox(network *net, image im);
 LIB_API float validate_detector_map(char *datacfg, char *cfgfile, char *weightfile, float thresh_calc_avg_iou, const float iou_thresh, const int map_points, int letter_box, network *existing_net);
 LIB_API void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, int ngpus, int clear, int dont_show, int calc_map, int mjpeg_port, int show_imgs, int benchmark_layers, char* chart_path);
 LIB_API void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filename, float thresh,
-    float hier_thresh, int dont_show, int ext_output, int save_labels, char *outfile, int letter_box, int benchmark_layers);
+    float hier_thresh, int dont_show, int ext_output, int save_labels, char *outfile, int letter_box,
+	int benchmark_layers, int print_detection_layer, int draw_label, int print_coordinate, int no_total, int print_warning); //êVÇµÇ¢test_detectorÇ…çáÇÌÇπÇÈ
 LIB_API int network_width(network *net);
 LIB_API int network_height(network *net);
 LIB_API void optimize_picture(network *net, image orig, int max_layer, float scale, float rate, float thresh, int norm);

--- a/src/coco.c
+++ b/src/coco.c
@@ -412,5 +412,5 @@ void run_coco(int argc, char **argv)
     else if(0==strcmp(argv[2], "valid")) validate_coco(cfg, weights);
     else if(0==strcmp(argv[2], "recall")) validate_coco_recall(cfg, weights);
     else if(0==strcmp(argv[2], "demo")) demo(cfg, weights, thresh, hier_thresh, cam_index, filename, coco_classes, 80, 1, frame_skip,
-		prefix, out_filename, mjpeg_port, 0, json_port, dont_show, ext_output, 0, 0, 0, 0, 0);
+		prefix, out_filename, mjpeg_port, 0, json_port, dont_show, ext_output, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0);
 }

--- a/src/darknet.c
+++ b/src/darknet.c
@@ -495,7 +495,7 @@ int main(int argc, char **argv)
         float thresh = find_float_arg(argc, argv, "-thresh", .24);
 		int ext_output = find_arg(argc, argv, "-ext_output");
         char *filename = (argc > 4) ? argv[4]: 0;
-        test_detector("cfg/coco.data", argv[2], argv[3], filename, thresh, 0.5, 0, ext_output, 0, NULL, 0, 0);
+        test_detector("cfg/coco.data", argv[2], argv[3], filename, thresh, 0.5, 0, ext_output, 0, NULL, 0, 0, 0, 0, 0, 1, 0); //êVÇµÇ¢detectorÇÃtest_detectorÇ…çáÇÌÇπÇΩ
     } else if (0 == strcmp(argv[1], "cifar")){
         run_cifar(argc, argv);
     } else if (0 == strcmp(argv[1], "go")){

--- a/src/demo.c
+++ b/src/demo.c
@@ -132,7 +132,7 @@ double get_wall_time()
 
 void demo(char *cfgfile, char *weightfile, float thresh, float hier_thresh, int cam_index, const char *filename, char **names, int classes, int avgframes,
     int frame_skip, char *prefix, char *out_filename, int mjpeg_port, int dontdraw_bbox, int json_port, int dont_show, int ext_output, int letter_box_in, int time_limit_sec, char *http_post_host,
-    int benchmark, int benchmark_layers)
+    int benchmark, int benchmark_layers, int mosaic_flag, int draw_label, int print_coordinate, int no_total, int show_frame_num, int print_fps, int print_warning)
 {
     if (avgframes < 1) avgframes = 1;
     avg_frames = avgframes;
@@ -270,9 +270,13 @@ void demo(char *cfgfile, char *weightfile, float thresh, float hier_thresh, int 
             //printf("\033[2J");
             //printf("\033[1;1H");
             //printf("\nFPS:%.1f\n", fps);
-            printf("Objects:\n\n");
+
+            //次のフレームorフレームIDを出力する
+            if (show_frame_num) printf("\n********%08d frame********\n", global_frame_counter);
+            else printf("\n**********next frame**********\n");
 
             ++frame_id;
+
             if (demo_json_port > 0) {
                 int timeout = 400000;
                 send_json(local_dets, local_nboxes, l.classes, demo_names, frame_id, demo_json_port, timeout);
@@ -289,10 +293,12 @@ void demo(char *cfgfile, char *weightfile, float thresh, float hier_thresh, int 
                 }
             }
 
-            if (!benchmark && !dontdraw_bbox) draw_detections_cv_v3(show_img, local_dets, local_nboxes, demo_thresh, demo_names, demo_alphabet, demo_classes, demo_ext_output);
+            //引数を増やしている
+            if (!benchmark && !dontdraw_bbox) draw_detections_cv_v3(show_img, local_dets, local_nboxes, demo_thresh, demo_names, demo_alphabet, demo_classes, demo_ext_output, mosaic_flag, draw_label, print_coordinate, no_total, print_warning);
             free_detections(local_dets, local_nboxes);
 
-            printf("\nFPS:%.1f \t AVG_FPS:%.1f\n", fps, avg_fps);
+            //FPSの表示
+            if (print_fps) printf("FPS:%.1f \t AVG_FPS:%.1f\n", fps, avg_fps);
 
             if(!prefix){
                 if (!dont_show) {
@@ -312,7 +318,7 @@ void demo(char *cfgfile, char *weightfile, float thresh, float hier_thresh, int 
                 }
             }else{
                 char buff[256];
-                sprintf(buff, "%s_%08d.jpg", prefix, count);
+                sprintf(buff, "video-prefix/%s_%08d.jpg", prefix, global_frame_counter);
                 if(show_img) save_cv_jpg(show_img, buff);
             }
 
@@ -324,10 +330,11 @@ void demo(char *cfgfile, char *weightfile, float thresh, float hier_thresh, int 
                 send_mjpeg(show_img, port, timeout, jpeg_quality);
             }
 
-            // save video file
+            // save video
             if (output_video_writer && show_img) {
                 write_frame_cv(output_video_writer, show_img);
-                printf("\n cvWriteFrame \n");
+                //表示の方法を少し変えた
+                printf("☆cvWriteFrame\n");
             }
 
             while (custom_atomic_load_int(&run_detect_in_thread)) {
@@ -415,7 +422,7 @@ void demo(char *cfgfile, char *weightfile, float thresh, float hier_thresh, int 
 #else
 void demo(char *cfgfile, char *weightfile, float thresh, float hier_thresh, int cam_index, const char *filename, char **names, int classes, int avgframes,
     int frame_skip, char *prefix, char *out_filename, int mjpeg_port, int dontdraw_bbox, int json_port, int dont_show, int ext_output, int letter_box_in, int time_limit_sec, char *http_post_host,
-    int benchmark, int benchmark_layers)
+    int benchmark, int benchmark_layers, int mosaic_flag, int draw_label, int print_coordinate, int no_total, int show_frame_num, int print_fps, int print_warning)
 {
     fprintf(stderr, "Demo needs OpenCV for webcam images.\n");
 }

--- a/src/demo.h
+++ b/src/demo.h
@@ -1,12 +1,13 @@
 #ifndef DEMO_H
-#define DEMO_H
+#define DEMO_Hlabel_flag
 
 #include "image.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
+//ˆø”‚ğ‘‚â‚µ‚Ä‚¢‚é
 void demo(char *cfgfile, char *weightfile, float thresh, float hier_thresh, int cam_index, const char *filename, char **names, int classes, int avgframes,
-    int frame_skip, char *prefix, char *out_filename, int mjpeg_port, int dontdraw_bbox, int json_port, int dont_show, int ext_output, int letter_box_in, int time_limit_sec, char *http_post_host, int benchmark, int benchmark_layers);
+    int frame_skip, char *prefix, char *out_filename, int mjpeg_port, int dontdraw_bbox, int json_port, int dont_show, int ext_output, int letter_box_in, int time_limit_sec, char *http_post_host, int benchmark, int benchmark_layers, int mosaic_flag, int draw_label, int print_coordinate, int no_total, int show_frame_num, int print_fps, int print_warning);
 #ifdef __cplusplus
 }
 #endif

--- a/src/detector.c
+++ b/src/detector.c
@@ -21,6 +21,8 @@ typedef __compar_fn_t comparison_fn_t;
 
 int check_mistakes = 0;
 
+int test = 0;
+
 static int coco_ids[] = { 1,2,3,4,5,6,7,8,9,10,11,13,14,15,16,17,18,19,20,21,22,23,24,25,27,28,31,32,33,34,35,36,37,38,39,40,41,42,43,44,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,67,70,72,73,74,75,76,77,78,79,80,81,82,84,85,86,87,88,89,90 };
 
 void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, int ngpus, int clear, int dont_show, int calc_map, int mjpeg_port, int show_imgs, int benchmark_layers, char* chart_path)
@@ -1590,9 +1592,9 @@ void calc_anchors(char *datacfg, int num_of_clusters, int width, int height, int
     getchar();
 }
 
-
 void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filename, float thresh,
-    float hier_thresh, int dont_show, int ext_output, int save_labels, char *outfile, int letter_box, int benchmark_layers)
+    float hier_thresh, int dont_show, int ext_output, int save_labels, char *outfile, int letter_box,
+    int benchmark_layers, int print_detection_layer, int draw_label, int print_coordinate, int no_total, int print_warning)
 {
     list *options = read_data_cfg(datacfg);
     char *name_list = option_find_str(options, "names", "data/names.list");
@@ -1645,16 +1647,20 @@ void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filenam
         //image sized = load_image_resize(input, net.w, net.h, net.c, &im);
         image im = load_image(input, 0, 0, net.c);
         image sized;
-        if(letter_box) sized = letterbox_image(im, net.w, net.h);
+        if (letter_box) sized = letterbox_image(im, net.w, net.h);
         else sized = resize_image(im, net.w, net.h);
 
+
         layer l = net.layers[net.n - 1];
-        int k;
-        for (k = 0; k < net.n; ++k) {
-            layer lk = net.layers[k];
-            if (lk.type == YOLO || lk.type == GAUSSIAN_YOLO || lk.type == REGION) {
-                l = lk;
-                printf(" Detection layer: %d - type = %d \n", k, l.type);
+        //Detection layerを出力
+        if (print_detection_layer) {
+            int k;
+            for (k = 0; k < net.n; ++k) {
+                layer lk = net.layers[k];
+                if (lk.type == YOLO || lk.type == GAUSSIAN_YOLO || lk.type == REGION) {
+                    l = lk;
+                    printf(" Detection layer: %d - type = %d \n", k, l.type);
+                }
             }
         }
 
@@ -1677,10 +1683,17 @@ void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filenam
             if (l.nms_kind == DEFAULT_NMS) do_nms_sort(dets, nboxes, l.classes, nms);
             else diounms_sort(dets, nboxes, l.classes, nms, l.nms_kind, l.beta_nms);
         }
-        draw_detections_v3(im, dets, nboxes, thresh, names, alphabet, l.classes, ext_output);
-        save_image(im, "predictions");
+
+        //画像を描写する
+        draw_detections_v3(im, dets, nboxes, thresh, names, alphabet, l.classes, ext_output, draw_label, print_coordinate, no_total, print_warning);
+
+        //画像の保存場所を画像がある場所にし，名前に-predictedを付け加える
+        char* split = strtok(input, ".");
+        char save_name[] = "default";
+        sprintf(save_name, "%s%s", split, "-predicted");
+        save_image(im, save_name);
         if (!dont_show) {
-            show_image(im, "predictions");
+            show_image(im, save_name);
         }
 
         if (json_file) {
@@ -1761,7 +1774,7 @@ void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filenam
 
 // adversarial attack dnn
 void draw_object(char *datacfg, char *cfgfile, char *weightfile, char *filename, float thresh, int dont_show, int it_num,
-    int letter_box, int benchmark_layers)
+    int letter_box, int benchmark_layers, int print_detection_layer, int draw_label, int print_coordinate, int no_total, int print_warning)
 {
     list *options = read_data_cfg(datacfg);
     char *name_list = option_find_str(options, "names", "data/names.list");
@@ -1813,12 +1826,15 @@ void draw_object(char *datacfg, char *cfgfile, char *weightfile, char *filename,
         image src_sized = copy_image(sized);
 
         layer l = net.layers[net.n - 1];
-        int k;
-        for (k = 0; k < net.n; ++k) {
-            layer lk = net.layers[k];
-            if (lk.type == YOLO || lk.type == GAUSSIAN_YOLO || lk.type == REGION) {
-                l = lk;
-                printf(" Detection layer: %d - type = %d \n", k, l.type);
+        //Detection layerを出力
+        if (print_detection_layer) {
+            int k;
+            for (k = 0; k < net.n; ++k) {
+                layer lk = net.layers[k];
+                if (lk.type == YOLO || lk.type == GAUSSIAN_YOLO || lk.type == REGION) {
+                    l = lk;
+                    printf(" Detection layer: %d - type = %d \n", k, l.type);
+                }
             }
         }
 
@@ -1882,10 +1898,17 @@ void draw_object(char *datacfg, char *cfgfile, char *weightfile, char *filename,
             if (l.nms_kind == DEFAULT_NMS) do_nms_sort(dets, nboxes, l.classes, nms);
             else diounms_sort(dets, nboxes, l.classes, nms, l.nms_kind, l.beta_nms);
         }
-        draw_detections_v3(sized, dets, nboxes, thresh, names, alphabet, l.classes, 1);
-        save_image(sized, "pre_predictions");
+
+        //画像を描写
+        draw_detections_v3(sized, dets, nboxes, thresh, names, alphabet, l.classes, 1, draw_label, print_coordinate, no_total, print_warning);
+
+        //画像の保存場所を画像がある場所にし，名前に-predictedを付け加える
+        char* split = strtok(input, ".");
+        char save_name[] = "default";
+        sprintf(save_name, "%s%s", split, "-pre_predicted");
+        save_image(im, save_name);
         if (!dont_show) {
-            show_image(sized, "pre_predictions");
+            show_image(im, save_name);
         }
 
         free_detections(dets, nboxes);
@@ -1960,6 +1983,18 @@ void run_detector(int argc, char **argv)
     int num_of_clusters = find_int_arg(argc, argv, "-num_of_clusters", 5);
     int width = find_int_arg(argc, argv, "-width", -1);
     int height = find_int_arg(argc, argv, "-height", -1);
+    /*** 追加したオプション ***/
+    /* 画像のみ */
+    int print_detection_layer = find_arg(argc, argv, "-print_detection_layer"); //detection_layerの表示を行う
+    /* 動画と画像 */
+    int draw_label = find_arg(argc, argv, "-draw_label"); //画像や動画にラベルを出力
+    int print_coordinate = find_arg(argc, argv, "-print_coordinate"); //標準出力を行う(座標や認識率の出力)
+    int no_total = find_arg(argc, argv, "-no_total"); //合計値を出力
+    int print_warning = find_arg(argc, argv, "-print_warning"); //警告の表示
+    /* 動画のみ */
+    int mosaic_flag = find_int_arg(argc, argv, "-mosaic", 0); //モザイクを入れる->0(モザイク無し),1(モザイクあり),2(bboxを描かない[フレーム取得用])
+    int show_frame_num = find_arg(argc, argv, "-show_frame"); //フレーム番号を出力
+    int print_fps = find_arg(argc, argv, "-print_fps");  //fpsを表示する
     // extended output in test mode (output of rect bound coords)
     // and for recall mode (extended output table-like format with results for best_class fit)
     int ext_output = find_arg(argc, argv, "-ext_output");
@@ -2002,7 +2037,7 @@ void run_detector(int argc, char **argv)
         if (strlen(weights) > 0)
             if (weights[strlen(weights) - 1] == 0x0d) weights[strlen(weights) - 1] = 0;
     char *filename = (argc > 6) ? argv[6] : 0;
-    if (0 == strcmp(argv[2], "test")) test_detector(datacfg, cfg, weights, filename, thresh, hier_thresh, dont_show, ext_output, save_labels, outfile, letter_box, benchmark_layers);
+    if (0 == strcmp(argv[2], "test")) test_detector(datacfg, cfg, weights, filename, thresh, hier_thresh, dont_show, ext_output, save_labels, outfile, letter_box, benchmark_layers, print_detection_layer, draw_label, print_coordinate, no_total, print_warning);
     else if (0 == strcmp(argv[2], "train")) train_detector(datacfg, cfg, weights, gpus, ngpus, clear, dont_show, calc_map, mjpeg_port, show_imgs, benchmark_layers, chart_path);
     else if (0 == strcmp(argv[2], "valid")) validate_detector(datacfg, cfg, weights, outfile);
     else if (0 == strcmp(argv[2], "recall")) validate_detector_recall(datacfg, cfg, weights);
@@ -2010,7 +2045,7 @@ void run_detector(int argc, char **argv)
     else if (0 == strcmp(argv[2], "calc_anchors")) calc_anchors(datacfg, num_of_clusters, width, height, show);
     else if (0 == strcmp(argv[2], "draw")) {
         int it_num = 100;
-        draw_object(datacfg, cfg, weights, filename, thresh, dont_show, it_num, letter_box, benchmark_layers);
+        draw_object(datacfg, cfg, weights, filename, thresh, dont_show, it_num, letter_box, benchmark_layers, print_detection_layer, draw_label, print_coordinate, no_total, print_warning);
     }
     else if (0 == strcmp(argv[2], "demo")) {
         list *options = read_data_cfg(datacfg);
@@ -2020,8 +2055,10 @@ void run_detector(int argc, char **argv)
         if (filename)
             if (strlen(filename) > 0)
                 if (filename[strlen(filename) - 1] == 0x0d) filename[strlen(filename) - 1] = 0;
+
+        //引数を増やしている
         demo(cfg, weights, thresh, hier_thresh, cam_index, filename, names, classes, avgframes, frame_skip, prefix, out_filename,
-            mjpeg_port, dontdraw_bbox, json_port, dont_show, ext_output, letter_box, time_limit_sec, http_post_host, benchmark, benchmark_layers);
+            mjpeg_port, dontdraw_bbox, json_port, dont_show, ext_output, letter_box, time_limit_sec, http_post_host, benchmark, benchmark_layers, mosaic_flag, draw_label, print_coordinate, no_total, show_frame_num, print_fps, print_warning);
 
         free_list_contents_kvp(options);
         free_list(options);

--- a/src/image.c
+++ b/src/image.c
@@ -20,6 +20,8 @@
 #include "stb_image_write.h"
 #endif
 
+#define DEFAULT_CLASS_NUM 64
+
 extern int check_mistakes;
 //int windows = 0;
 
@@ -326,7 +328,7 @@ int compare_by_probs(const void *a_ptr, const void *b_ptr) {
     return delta < 0 ? -1 : delta > 0 ? 1 : 0;
 }
 
-void draw_detections_v3(image im, detection *dets, int num, float thresh, char **names, image **alphabet, int classes, int ext_output)
+void draw_detections_v3(image im, detection* dets, int num, float thresh, char** names, image** alphabet, int classes, int ext_output, int draw_label, int print_coordinate, int no_total, int print_warning)
 {
     static int frame_id = 0;
     frame_id++;
@@ -334,31 +336,58 @@ void draw_detections_v3(image im, detection *dets, int num, float thresh, char *
     int selected_detections_num;
     detection_with_class* selected_detections = get_actual_detections(dets, num, thresh, &selected_detections_num, names);
 
-    // text output
-    qsort(selected_detections, selected_detections_num, sizeof(*selected_detections), compare_by_lefts);
-    int i;
-    for (i = 0; i < selected_detections_num; ++i) {
-        const int best_class = selected_detections[i].best_class;
-        printf("%s: %.0f%%", names[best_class],    selected_detections[i].det.prob[best_class] * 100);
-        if (ext_output)
-            printf("\t(left_x: %4.0f   top_y: %4.0f   width: %4.0f   height: %4.0f)\n",
-                round((selected_detections[i].det.bbox.x - selected_detections[i].det.bbox.w / 2)*im.w),
-                round((selected_detections[i].det.bbox.y - selected_detections[i].det.bbox.h / 2)*im.h),
-                round(selected_detections[i].det.bbox.w*im.w), round(selected_detections[i].det.bbox.h*im.h));
-        else
-            printf("\n");
-        int j;
-        for (j = 0; j < classes; ++j) {
-            if (selected_detections[i].det.prob[j] > thresh && j != best_class) {
-                printf("%s: %.0f%%", names[j], selected_detections[i].det.prob[j] * 100);
+    // 画像内のクラスの数を出力する
+    if (!no_total) {
+        int class_id_counter[DEFAULT_CLASS_NUM] = { 0 }; //カウンター
+        int i;
+        for (i = 0; i < selected_detections_num; ++i) {
+            const int best_class = selected_detections[i].best_class;
+            class_id_counter[best_class] += 1;
+        }
+        printf("---class numbers---\n");
+        for (i = 0; i < classes && i < DEFAULT_CLASS_NUM; ++i) printf("%s: %d\n", names[i], class_id_counter[i]);
+    }
 
-                if (ext_output)
-                    printf("\t(left_x: %4.0f   top_y: %4.0f   width: %4.0f   height: %4.0f)\n",
-                        round((selected_detections[i].det.bbox.x - selected_detections[i].det.bbox.w / 2)*im.w),
-                        round((selected_detections[i].det.bbox.y - selected_detections[i].det.bbox.h / 2)*im.h),
-                        round(selected_detections[i].det.bbox.w*im.w), round(selected_detections[i].det.bbox.h*im.h));
-                else
-                    printf("\n");
+    if (print_warning) {
+        // 警告欄
+        printf("---警告---\n");
+        /*
+        // 立ってる人が多かったら、警告
+        if (class_id_counter[1] > 6) printf("沢山の人が立っています！\n");
+        // 立っていて、つり革を持っていない人が5人以上いたら警告
+        if (abs(class_id_counter[0] - class_id_counter[1]) >= 3) printf("つり革の持っている人が少ないです！\n");
+        */
+    }
+
+    //条件分岐的に外に出した
+    int i;
+
+    // text output
+    if (print_coordinate) {
+        qsort(selected_detections, selected_detections_num, sizeof(*selected_detections), compare_by_lefts);
+        for (i = 0; i < selected_detections_num; ++i) {
+            const int best_class = selected_detections[i].best_class;
+            printf("%s: %.0f%%", names[best_class], selected_detections[i].det.prob[best_class] * 100);
+            if (ext_output)
+                printf("\t(left_x: %4.0f   top_y: %4.0f   width: %4.0f   height: %4.0f)\n",
+                    round((selected_detections[i].det.bbox.x - selected_detections[i].det.bbox.w / 2) * im.w),
+                    round((selected_detections[i].det.bbox.y - selected_detections[i].det.bbox.h / 2) * im.h),
+                    round(selected_detections[i].det.bbox.w * im.w), round(selected_detections[i].det.bbox.h * im.h));
+            else
+                printf("\n");
+            int j;
+            for (j = 0; j < classes; ++j) {
+                if (selected_detections[i].det.prob[j] > thresh && j != best_class) {
+                    printf("%s: %.0f%%", names[j], selected_detections[i].det.prob[j] * 100);
+
+                    if (ext_output)
+                        printf("\t(left_x: %4.0f   top_y: %4.0f   width: %4.0f   height: %4.0f)\n",
+                            round((selected_detections[i].det.bbox.x - selected_detections[i].det.bbox.w / 2) * im.w),
+                            round((selected_detections[i].det.bbox.y - selected_detections[i].det.bbox.h / 2) * im.h),
+                            round(selected_detections[i].det.bbox.w * im.w), round(selected_detections[i].det.bbox.h * im.h));
+                    else
+                        printf("\n");
+                }
             }
         }
     }
@@ -431,24 +460,29 @@ void draw_detections_v3(image im, detection *dets, int num, float thresh, char *
             else {
                 draw_box_width(im, left, top, right, bot, width, red, green, blue); // 3 channels RGB
             }
-            if (alphabet) {
-                char labelstr[4096] = { 0 };
-                strcat(labelstr, names[selected_detections[i].best_class]);
-                char prob_str[10];
-                sprintf(prob_str, ": %.2f", selected_detections[i].det.prob[selected_detections[i].best_class]);
-                strcat(labelstr, prob_str);
-                int j;
-                for (j = 0; j < classes; ++j) {
-                    if (selected_detections[i].det.prob[j] > thresh && j != selected_detections[i].best_class) {
-                        strcat(labelstr, ", ");
-                        strcat(labelstr, names[j]);
+
+            // 画像内に文字を表示する
+            if (draw_label) {
+                if (alphabet) {
+                    char labelstr[4096] = { 0 };
+                    strcat(labelstr, names[selected_detections[i].best_class]);
+                    char prob_str[10];
+                    sprintf(prob_str, ": %.2f", selected_detections[i].det.prob[selected_detections[i].best_class]);
+                    strcat(labelstr, prob_str);
+                    int j;
+                    for (j = 0; j < classes; ++j) {
+                        if (selected_detections[i].det.prob[j] > thresh && j != selected_detections[i].best_class) {
+                            strcat(labelstr, ", ");
+                            strcat(labelstr, names[j]);
+                        }
                     }
+                    image label = get_label_v3(alphabet, labelstr, (im.h * .02));
+                    //draw_label(im, top + width, left, label, rgb);
+                    draw_weighted_label(im, top + width, left, label, rgb, 0.7);
+                    free_image(label);
                 }
-                image label = get_label_v3(alphabet, labelstr, (im.h*.02));
-                //draw_label(im, top + width, left, label, rgb);
-                draw_weighted_label(im, top + width, left, label, rgb, 0.7);
-                free_image(label);
             }
+
             if (selected_detections[i].det.mask) {
                 image mask = float_to_image(14, 14, 1, selected_detections[i].det.mask);
                 image resized_mask = resize_image(mask, b.w*im.w, b.h*im.h);
@@ -458,6 +492,9 @@ void draw_detections_v3(image im, detection *dets, int num, float thresh, char *
                 free_image(resized_mask);
                 free_image(tmask);
             }
+
+            //改行を入れて見やすくする
+            printf("\n");
     }
     free(selected_detections);
 }

--- a/src/image.h
+++ b/src/image.h
@@ -31,7 +31,7 @@ void draw_label(image a, int r, int c, image label, const float *rgb);
 void draw_weighted_label(image a, int r, int c, image label, const float *rgb, const float alpha);
 void write_label(image a, int r, int c, image *characters, char *string, float *rgb);
 void draw_detections(image im, int num, float thresh, box *boxes, float **probs, char **names, image **labels, int classes);
-void draw_detections_v3(image im, detection *dets, int num, float thresh, char **names, image **alphabet, int classes, int ext_output);
+void draw_detections_v3(image im, detection *dets, int num, float thresh, char **names, image **alphabet, int classes, int ext_output, int draw_label, int print_coordinate, int no_total, int print_warning); //’Ç‹L
 image image_distance(image a, image b);
 void scale_image(image m, float s);
 // image crop_image(image im, int dx, int dy, int w, int h);

--- a/src/image_opencv.h
+++ b/src/image_opencv.h
@@ -89,8 +89,8 @@ image get_image_from_stream_letterbox(cap_cv *cap, int w, int h, int c, mat_cv**
 void save_cv_png(mat_cv *img, const char *name);
 void save_cv_jpg(mat_cv *img, const char *name);
 
-// Draw Detection
-void draw_detections_cv_v3(mat_cv* show_img, detection *dets, int num, float thresh, char **names, image **alphabet, int classes, int ext_output);
+// Draw Detection(ˆø”‚ğ‘‚â‚µ‚Ä‚¢‚é)
+void draw_detections_cv_v3(mat_cv* show_img, detection *dets, int num, float thresh, char **names, image **alphabet, int classes, int ext_output, int mosaic_flag, int draw_label, int print_coordinate, int no_total, int print_warning);
 
 // Draw Loss & Accuracy chart
 mat_cv* draw_train_chart(char *windows_name, float max_img_loss, int max_batches, int number_of_lines, int img_size, int dont_show, char* chart_path);

--- a/src/utils.c
+++ b/src/utils.c
@@ -125,7 +125,9 @@ int find_int_arg(int argc, char **argv, char *arg, int def)
     for(i = 0; i < argc-1; ++i){
         if(!argv[i]) continue;
         if(0==strcmp(argv[i], arg)){
-            def = atoi(argv[i+1]);
+            //“ü—Í‚ªNULL‚¾‚Á‚½‚çAŽ©“®‚Å1‚É‚·‚é
+            if (argv[i+1] == NULL) def = 1;
+            else def = atoi(argv[i + 1]);
             del_arg(argc, argv, i);
             del_arg(argc, argv, i);
             break;

--- a/src/yolo.c
+++ b/src/yolo.c
@@ -364,5 +364,5 @@ void run_yolo(int argc, char **argv)
     else if(0==strcmp(argv[2], "valid")) validate_yolo(cfg, weights);
     else if(0==strcmp(argv[2], "recall")) validate_yolo_recall(cfg, weights);
     else if(0==strcmp(argv[2], "demo")) demo(cfg, weights, thresh, hier_thresh, cam_index, filename, voc_names, 20, 1, frame_skip,
-		prefix, out_filename, mjpeg_port, 0, json_port, dont_show, ext_output, 0, 0, 0, 0, 0);
+		prefix, out_filename, mjpeg_port, 0, json_port, dont_show, ext_output, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0);
 }


### PR DESCRIPTION
**書き加えたファイル**

> include

- darknet.h

> src

- coco.c
- darknet.c
- demo.c
- demo.h
- detector.c
- image.c
- image.h
- image_opencv.cpp
- image_opencv.h
- util.c
- yolo.c

---

**追加したオプション**

> 画像のみ(test only)

- `-print_detection_layer` detection_layerの表示を行う

> 動画と画像(test & demo)

- `-draw_label` 画像や動画にラベルを出力
- `-print_coordinate` 標準出力を行う(座標や認識率の出力)
- `-no_total` 合計値を出力しなくする
- `-print_warning` 警告の表示

> 動画のみ(demo only)

- `-mosaic [num]` モザイクを入れる[num]->0(無),1(有),2(bboxを描かない[フレーム取得用])
- `-show_frame` フレーム番号を出力
- `-print_fps` fpsを表示する